### PR TITLE
Add MCP2515 clock setting and note for it

### DIFF
--- a/examples/EMUcan_MCP2515/EMUcan_MCP2515.ino
+++ b/examples/EMUcan_MCP2515/EMUcan_MCP2515.ino
@@ -3,6 +3,9 @@
 // Example to be run on Arduino (Nano) with MCP2515
 // Configure the EMU Black to send the CAN Stream at 500KBPS
 
+// Hint:
+// Check the Clock on your MCP2515 Board, change MCP_8MHZ to fit.
+
 // This MCP2515 Lib is used:
 // https://github.com/autowp/arduino-mcp2515
 
@@ -33,7 +36,7 @@ void setup() {
   Serial.println("------- CAN Read ----------");
 
   mcp2515.reset();
-  mcp2515.setBitrate(CAN_500KBPS);
+  mcp2515.setBitrate(CAN_500KBPS, MCP_8MHZ);
   mcp2515.setNormalMode();
 }
 

--- a/examples/EMUcan_MCP2515_send/EMUcan_MCP2515_send.ino
+++ b/examples/EMUcan_MCP2515_send/EMUcan_MCP2515_send.ino
@@ -8,6 +8,9 @@
 // Use this file: EMUBlackCANStreamExample.canstr
 // It will receive the values as CAN Analog 1 and 2.
 
+// Hint:
+// Check the Clock on your MCP2515 Board, change MCP_8MHZ to fit.
+
 // This MCP2515 Lib is used:
 // https://github.com/autowp/arduino-mcp2515
 
@@ -38,7 +41,7 @@ void setup() {
   Serial.println("------- CAN Read ----------");
 
   mcp2515.reset();
-  mcp2515.setBitrate(CAN_500KBPS);
+  mcp2515.setBitrate(CAN_500KBPS, MCP_8MHZ);
   mcp2515.setNormalMode();
 }
 


### PR DESCRIPTION
This is fixing https://github.com/designer2k2/EMUcan/issues/13 by adding the MCP2515 clock setting and a reminder that it has to be checked.